### PR TITLE
enable nn3 to be executed with commandline options

### DIFF
--- a/nextnanopy/nn3/defaults.py
+++ b/nextnanopy/nn3/defaults.py
@@ -48,10 +48,10 @@ def command_nn3(
         outputdirectory,
         threads=0,
         debuglevel=0,
-        #dubuglevel=-1,
+        #dubuglevel=-1,             # pending change
         cancel=-1,
         softkill=-1,
-        #system='default',
+        #system='default',          # pending change
         **kwargs,
 ):
     kwargs = OrderedDict(
@@ -64,7 +64,7 @@ def command_nn3(
         debuglevel=['-debuglevel', debuglevel],
         cancel=['-cancel', cancel],
         softkill=['-softkill', softkill],
-        #system=['-system', system],
+        #system=['-system', system],        # pending change
         no_file_options=[kwargs['no_file_options'], ''] if 'no_file_options' in kwargs else ['', ''],
     )
     return generate_command(kwargs.values())

--- a/nextnanopy/nn3/defaults.py
+++ b/nextnanopy/nn3/defaults.py
@@ -32,6 +32,14 @@ config_default = {
 }
 
 
+"""
+The option 'system' should be implemented once we convince that everyone uses the later version of nn3 than 2021_12_24.
+Also the default value of debuglevel should be a negative integer. (i.e. ignore the flag)
+We only need to comment out the 3 corresponding lines.
+
+About the difference of '-...' and '--...', '--license' will also work and should be the new default.
+For backwards compatibility, we keep '-license' for the moment.
+"""
 def command_nn3(
         inputfile,
         exe,
@@ -40,8 +48,10 @@ def command_nn3(
         outputdirectory,
         threads=0,
         debuglevel=0,
+        #dubuglevel=-1,
         cancel=-1,
         softkill=-1,
+        #system='default',
         **kwargs,
 ):
     kwargs = OrderedDict(
@@ -54,6 +64,8 @@ def command_nn3(
         debuglevel=['-debuglevel', debuglevel],
         cancel=['-cancel', cancel],
         softkill=['-softkill', softkill],
+        #system=['-system', system],
+        no_file_options=[kwargs['no_file_options'], ''] if 'no_file_options' in kwargs else ['', ''],
     )
     return generate_command(kwargs.values())
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,9 +40,10 @@ class TestCommands(unittest.TestCase):
         debuglevel = 0
         cancel = -1
         softkill = -1
-        cmd = f'"{exe}" -license "{license}" -inputfile "{inputfile}" -database "{database}" -threads {threads} -outputdirectory "{outputdirectory}" -debuglevel {debuglevel} -cancel {cancel} -softkill {softkill}'
+        no_file_options = '-log -parse'
+        cmd = f'"{exe}" -license "{license}" -inputfile "{inputfile}" -database "{database}" -threads {threads} -outputdirectory "{outputdirectory}" -debuglevel {debuglevel} -cancel {cancel} -softkill {softkill} {no_file_options}'
         kwargs = dict(inputfile=inputfile, exe=exe, license=license, database=database, outputdirectory=outputdirectory,
-                      threads=threads, debuglevel=debuglevel, cancel=cancel, softkill=softkill)
+                      threads=threads, debuglevel=debuglevel, cancel=cancel, softkill=softkill, no_file_options=no_file_options)
         from nextnanopy.nn3.defaults import command_nn3
         self.assertEqual(command_nn3(**kwargs), cmd)
         self.assertEqual(commands.command(**kwargs), cmd)


### PR DESCRIPTION
## Why

Some commandline options are not supported by the execution in nnpy.

## What is changing

add the commandline options for nn3 that have no subsequent values or files.
Now the following options are supported:
- `-log`
- `-condor`
- `-parse`

These are specified as `no_file_options` like

```
info = input_file.execute(cancel=2, no_file_options='-parse -log')
```

(Also, `-system` option should be supported at some point.
The changes to include `system` are written as comment.)
